### PR TITLE
Update ovn playbook mappings

### DIFF
--- a/mapping3.yml
+++ b/mapping3.yml
@@ -217,6 +217,8 @@ octavia-certificates: kolla
 octavia: kolla
 openvswitch: kolla
 ovn: kolla
+ovn-controller: kolla
+ovn-db: kolla
 ovs-dpdk: kolla
 panko: kolla
 placement: kolla

--- a/mapping4.yml
+++ b/mapping4.yml
@@ -194,6 +194,8 @@ kolla:
 - octavia
 - openvswitch
 - ovn
+- ovn-controller
+- ovn-db
 - ovs-dpdk
 - panko
 - placement


### PR DESCRIPTION
Kolla-ansible has split the ovn role into ovn-db and ovn-controller in the Zed cycle, update the playbook mappings accordingly

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>